### PR TITLE
Fix leading `<style>` regression

### DIFF
--- a/.changeset/dry-years-impress.md
+++ b/.changeset/dry-years-impress.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix regression where leading `<style>` elements could break generated tags

--- a/internal/node.go
+++ b/internal/node.go
@@ -30,6 +30,9 @@ const (
 	ExpressionNode
 )
 
+// Used as an Attribute Key to mark implicit nodes
+const ImplicitNodeMarker = "\x00implicit"
+
 // Section 12.2.4.3 says "The markers are inserted when entering applet,
 // object, marquee, template, td, th, and caption elements, and are used
 // to prevent formatting from "leaking" into applet, object, marquee,

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -2670,6 +2670,7 @@ func (p *parser) parseImpliedToken(t TokenType, dataAtom a.Atom, data string) {
 		Type:     t,
 		DataAtom: dataAtom,
 		Data:     data,
+		Attr:     []Attribute{{Key: ImplicitNodeMarker, Type: EmptyAttribute}},
 	}
 	p.hasSelfClosingToken = false
 	p.parseCurrentToken()

--- a/internal/print-to-source.go
+++ b/internal/print-to-source.go
@@ -16,6 +16,9 @@ func PrintToSource(buf *strings.Builder, node *Node) {
 	case ElementNode:
 		buf.WriteString(fmt.Sprintf(`<%s`, node.Data))
 		for _, attr := range node.Attr {
+			if attr.Key == ImplicitNodeMarker {
+				continue
+			}
 			if attr.Namespace != "" {
 				buf.WriteString(attr.Namespace)
 				buf.WriteString(":")

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -382,6 +382,9 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 		p.print(`]`)
 	} else {
 		for _, a := range n.Attr {
+			if transform.IsImplictNodeMarker(a) {
+				continue
+			}
 			if a.Key == "slot" {
 				if !(n.Parent.Component || n.Parent.CustomElement) {
 					panic(`Element with a slot='...' attribute must be a child of a component or a descendant of a custom element`)

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1223,6 +1223,13 @@ const items = ["Dog", "Cat", "Platipus"];
 				code: `${$$renderComponent($$result,'Base',Base,{"title":"Home"},{"default": () => $$render` + BACKTICK + `<div>Hello</div>` + BACKTICK + `,})}`,
 			},
 		},
+		{
+			name:   "user-defined `implicit` is printed",
+			source: `<html implicit></html>`,
+			want: want{
+				code: `<html implicit><head></head><body></body></html>`,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1213,7 +1213,7 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "textarea in form",
 			source: `<html><Component><form><textarea></textarea></form></Component></html>`,
 			want: want{
-				code: `<html><body>${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + BACKTICK + `<form><textarea></textarea></form>` + BACKTICK + `,})}</body></html>`,
+				code: `<html>${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + BACKTICK + `<form><textarea></textarea></form>` + BACKTICK + `,})}</html>`,
 			},
 		},
 		{

--- a/internal/transform/utils.go
+++ b/internal/transform/utils.go
@@ -25,6 +25,25 @@ func HasAttr(n *astro.Node, key string) bool {
 	return false
 }
 
+func IsImplictNode(n *astro.Node) bool {
+	return HasAttr(n, astro.ImplicitNodeMarker)
+}
+
+func IsImplictNodeMarker(attr astro.Attribute) bool {
+	return attr.Key == astro.ImplicitNodeMarker
+}
+
+func childCount(n *astro.Node) int {
+	var i int
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if IsImplictNode(c) {
+			continue
+		}
+		i++
+	}
+	return i
+}
+
 func GetQuotedAttr(n *astro.Node, key string) string {
 	for _, attr := range n.Attr {
 		if attr.Key == key {


### PR DESCRIPTION
## Changes

- Closes https://github.com/snowpackjs/astro/issues/1989
- The problem here was a regression in the handling of leading `<script hoist>` or `<style>` nodes (implemented in https://github.com/snowpackjs/astro-compiler/pull/154)
- The fix required two changes:
  - Tracking which elements are implicitly generated while parsing the document.
  - Being more intelligent about repairing a document after elements have been hoisted out

## Testing

Many tests added

## Docs

Bug fix only
