### PR TITLE
Fix typo

### DIFF
--- a/.changeset/early-tips-lick.md
+++ b/.changeset/early-tips-lick.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix edge case with files that contain a single component

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -184,7 +184,7 @@ func hasSiblings(n *tycho.Node) bool {
 
 	if sibling := n.PrevSibling; sibling != nil {
 		if sibling.Type == tycho.TextNode {
-			return strings.TrimSpace(n.NextSibling.Data) != ""
+			return strings.TrimSpace(n.PrevSibling.Data) != ""
 		} else {
 			return sibling.Type != tycho.CommentNode
 		}

--- a/internal/transform/transform_test.go
+++ b/internal/transform/transform_test.go
@@ -154,6 +154,11 @@ func TestFullTransform(t *testing.T) {
 			source: `<Component />`,
 			want:   `<Component></Component>`,
 		},
+		{
+			name:   "",
+			source: `<style></style><A><div><B /></div></A>`,
+			want:   `<A><div><B></B></div></A>`,
+		},
 	}
 	var b strings.Builder
 	for _, tt := range tests {

--- a/lib/compiler/test/component-only.test.mjs
+++ b/lib/compiler/test/component-only.test.mjs
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 import { transform } from '@astrojs/compiler';
 import sass from 'sass';
 
@@ -46,14 +48,14 @@ import Layout from '../layouts/content.astro';
         }
         return null;
       },
-      as: 'document'
+      as: 'document',
     }
   );
 
-  console.log(result.code)
+  console.log(result.code);
 
   if (result.code.includes('html')) {
-    throw new Error('Result did not remove <html>')
+    throw new Error('Result did not remove <html>');
   }
 }
 

--- a/lib/compiler/test/component-only.test.mjs
+++ b/lib/compiler/test/component-only.test.mjs
@@ -17,21 +17,26 @@ function transformSass(value) {
 async function run() {
   const result = await transform(
     `---
-let value = 'world';
+import { Markdown } from 'astro/components';
+import Layout from '../layouts/content.astro';
 ---
 
-<style lang="scss"></style>
+<style>
+  #root {
+    color: green;
+  }
+</style>
 
-<div>Hello world!</div>
-
-<div>Ahhh</div>
-`,
+<Layout>
+  <div id="root">
+    <Markdown>
+      ## Interesting Topic
+    </Markdown>
+  </div>
+</Layout>`, // NOTE: the lack of trailing space is important to this test!
     {
       sourcemap: true,
       preprocessStyle: async (value, attrs) => {
-        if (!attrs.lang) {
-          return null;
-        }
         if (attrs.lang === 'scss') {
           try {
             return transformSass(value);
@@ -41,8 +46,15 @@ let value = 'world';
         }
         return null;
       },
+      as: 'document'
     }
   );
+
+  console.log(result.code)
+
+  if (result.code.includes('html')) {
+    throw new Error('Result did not remove <html>')
+  }
 }
 
 await run();

--- a/lib/compiler/test/empty-style.test.mjs
+++ b/lib/compiler/test/empty-style.test.mjs
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 import { transform } from '@astrojs/compiler';
 import sass from 'sass';
 

--- a/lib/compiler/test/test.mjs
+++ b/lib/compiler/test/test.mjs
@@ -1,3 +1,4 @@
 import './basic.test.mjs';
+import './component-only.test.mjs';
 import './empty-style.test.mjs';
 import './output.test.mjs';


### PR DESCRIPTION
## Changes

- Files with a single root component but no trailing whitespace were throwing because I had a copy+paste typo.

## Testing

Tests added to catch this in the future

## Docs

Bug fix
