### PR TITLE
Remove GOPATH references.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,6 @@ Contributions are welcome to the Go compiler!
 
 [Go][go] `1.17.x` is needed to work with this repo. On Macs, installing via [Homebrew][homebrew] is recommended: `brew install go`. For Windows & Linux, you can [follow Go’s installation guide][go] if you don’t have your own preferred method of package installation.
 
-By default, Go will set `$GOPATH` to a new `./go/` directory in your home folder. For best support with VS Code and tooling, it’s recommended to place Go projects like this one in here. So for this project, that would mean cloning it to `~/go/src/github.com/snowpackjs/astro-compiler-next`. You can change this path, but it does require some understanding. Read [Understanding the GOPATH][gopath] to learn more.
-
 If you use VS Code as your primary editor, installing the [Go extension][go-vscode] is highly recommended.
 
 ### TinyGo
@@ -50,7 +48,6 @@ Adding tests for the tokenizer, scanner, and printer can be found in `internal/t
 [homebrew]: https://brew.sh/
 [go]: https://golang.org/
 [go-vscode]: https://marketplace.visualstudio.com/items?itemName=golang.go
-[gopath]: https://www.digitalocean.com/community/tutorials/understanding-the-gopath
 [node]: https://nodejs.org/
 [tinygo]: https://tinygo.org/
 [tinygo-install]: https://tinygo.org/getting-started/install/

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ GO_FLAGS += "-ldflags=-s -w"
 # Avoid embedding the build path in the executable for more reproducible builds
 GO_FLAGS += -trimpath
 
-astro: cmd/astro/*.go pkg/*/*.go internal/*/*.go go.mod
+astro: cmd/astro/*.go internal/*/*.go go.mod
 	CGO_ENABLED=0 go build $(GO_FLAGS) ./cmd/astro
 
-astro-wasm: cmd/astro/*.go pkg/*/*.go internal/*/*.go go.mod
+astro-wasm: cmd/astro/*.go internal/*/*.go go.mod
 	tinygo build -no-debug -o ./lib/compiler/astro.wasm -target wasm ./cmd/astro-wasm/astro-wasm.go
 	cp ./lib/compiler/astro.wasm ./lib/compiler/deno/astro.wasm
 


### PR DESCRIPTION
The code does not need to be checked out under GOPATH to build.

## Changes
Remove unneeded pkg/ prerequisites in Makefile, and references to GOPATH from the docs.
With new Go versions and using modules, packages don't need to be checked out under GOPATH.

## Testing

make astro
make astro-wasm

## Docs
this affects dev docs only.
