### PR TITLE
feat: implement new `fragment` behavior to support `head` and `body`

### DIFF
--- a/.changeset/small-beds-perform.md
+++ b/.changeset/small-beds-perform.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+Change behavior of `as: "fragment"` option to support arbitrary `head` and `body` tags

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -126,8 +126,8 @@ func Transform() interface{} {
 			} else if transformOptions.As == "fragment" {
 				nodes, err := astro.ParseFragment(strings.NewReader(source), &astro.Node{
 					Type:     astro.ElementNode,
-					Data:     atom.Body.String(),
-					DataAtom: atom.Body,
+					Data:     atom.Template.String(),
+					DataAtom: atom.Template,
 				})
 				if err != nil {
 					fmt.Println(err)

--- a/internal/token.go
+++ b/internal/token.go
@@ -1849,16 +1849,3 @@ func NewTokenizerFragment(r io.Reader, contextTag string) *Tokenizer {
 	}
 	return z
 }
-
-// NewTokenizer returns a new HTML Tokenizer for the given Reader.
-// The input is assumed to be UTF-8 encoded.
-func NewAttributeTokenizer(r io.Reader) *Tokenizer {
-	buf := new(bytes.Buffer)
-	buf.ReadFrom(r)
-	z := &Tokenizer{
-		r:   r,
-		buf: buf.Bytes(),
-		fm:  FrontmatterClosed,
-	}
-	return z
-}

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -38,7 +38,7 @@ func Transform(doc *tycho.Node, opts TransformOptions) *tycho.Node {
 	// Sometimes files have leading <script hoist> or <style>...
 	// Since we can't detect a "component-only" file until after `parse`, we need to handle
 	// them here. The component will be hoisted to the root of the document, `html` and `head` will be removed.
-	if opts.As != "Fragment" {
+	if opts.As != "fragment" {
 		var onlyComponent *tycho.Node
 		var rootNode *tycho.Node
 		walk(doc, func(n *tycho.Node) {

--- a/lib/compiler/test/body-fragment.test.mjs
+++ b/lib/compiler/test/body-fragment.test.mjs
@@ -1,0 +1,29 @@
+/* eslint-disable no-console */
+
+import { transform } from '@astrojs/compiler';
+
+async function run() {
+  const result = await transform(
+    `---
+import ThemeToggleButton from './ThemeToggleButton.tsx';
+---
+
+<title>Uhhh</title>
+
+<body><div>Hello!</div></body>`,
+    {
+      sourcemap: true,
+      as: 'fragment',
+      site: undefined,
+      sourcefile: 'MoreMenu.astro',
+      sourcemap: 'both',
+      internalURL: 'astro/internal',
+    }
+  );
+
+  if (!result.code.includes('<body><div>Hello!</div></body>')) {
+    throw new Error('Expected output to contain <body><div>Hello!</div></body>');
+  }
+}
+
+await run();

--- a/lib/compiler/test/component-only.test.mjs
+++ b/lib/compiler/test/component-only.test.mjs
@@ -52,8 +52,6 @@ import Layout from '../layouts/content.astro';
     }
   );
 
-  console.log(result.code);
-
   if (result.code.includes('html')) {
     throw new Error('Result did not remove <html>');
   }

--- a/lib/compiler/test/test.mjs
+++ b/lib/compiler/test/test.mjs
@@ -1,4 +1,5 @@
 import './basic.test.mjs';
+import './body-fragment.test.mjs';
 import './component-only.test.mjs';
 import './empty-style.test.mjs';
 import './output.test.mjs';


### PR DESCRIPTION
## Changes

- Fixes https://github.com/withastro/astro/issues/2031
- Allows `body` and `head` (any arbitrary tag) inside of components when using `as: "fragment"`.
- This may become the default behavior (eventually).

## Testing

WASM test added as that's the only area this behavior is surfaced

## Docs

Bug fix
